### PR TITLE
Allow non-existant output if no doctests

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -2,4 +2,5 @@ doctest-csharp.sln.DotSettings.user
 obj/
 bin/
 out/
+coverage.json
 coverage.opencover.xml

--- a/src/DoctestCsharp.Test/TestProgram.cs
+++ b/src/DoctestCsharp.Test/TestProgram.cs
@@ -5,6 +5,7 @@ using DirectoryInfo = System.IO.DirectoryInfo;
 using Environment = System.Environment;
 
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace DoctestCsharp.Test
 {
@@ -66,7 +67,7 @@ namespace DoctestCsharp.Test
 
             Assert.AreEqual(0, exitCode);
             Assert.AreEqual(
-                $"No doctests found in: {inputPath}; not generating {outputPath}{nl}",
+                $"No doctests found in: {inputPath}{nl}",
                 consoleCapture.Output());
         }
 
@@ -268,6 +269,29 @@ namespace Tests
             Assert.AreEqual(1, exitCode);
             Assert.AreEqual(
                 $"No doctests found in: {inputPath}; the output should not exist: {outputPath}{nl}",
+                consoleCapture.Output());
+        }
+
+        [Test]
+        public void TestOutputMayNotExistIfNoDoctests()
+        {
+            using var tmpdir = new TemporaryDirectory();
+            DirectoryInfo input = Directory.CreateDirectory(Path.Join(tmpdir.Path, "SomeProject"));
+            string output = Path.Join(tmpdir.Path, "SomeProject.Test/doctests");
+            Assert.IsFalse(File.Exists(output));
+
+            string inputPath = Path.Join(input.FullName, "SomeProgram.cs");
+            File.WriteAllText(inputPath, "no doctests");
+
+            using var consoleCapture = new ConsoleCapture();
+
+            int exitCode = Program.MainWithCode(new[] { "--input", input.FullName, "--output", output, "--check" });
+
+            string nl = Environment.NewLine;
+
+            Assert.AreEqual(0, exitCode);
+            Assert.AreEqual(
+                $"OK, no doctests: {inputPath}{nl}",
                 consoleCapture.Output());
         }
     }

--- a/src/DoctestCsharp/Program.cs
+++ b/src/DoctestCsharp/Program.cs
@@ -59,7 +59,7 @@ namespace DoctestCsharp
                     Console.WriteLine(
                         generated
                         ? $"Generated doctest(s) for: {inputPath} -> {outputPath}"
-                        : $"No doctests found in: {inputPath}; not generating {outputPath}");
+                        : $"No doctests found in: {inputPath}");
                 }
                 else
                 {
@@ -67,7 +67,10 @@ namespace DoctestCsharp
                     switch (report)
                     {
                         case Process.Report.Ok:
-                            Console.WriteLine($"OK: {inputPath} -> {outputPath}");
+                            Console.WriteLine(
+                                (doctests.Count > 0)
+                                    ? $"OK: {inputPath} -> {outputPath}"
+                                    : $"OK, no doctests: {inputPath}");
                             break;
                         case Process.Report.Different:
                             Console.WriteLine($"Expected different content: {inputPath} -> {outputPath}");
@@ -114,7 +117,7 @@ namespace DoctestCsharp
                     "Output directory where the test source code will be generated.")
                 {
                     Required = true,
-                    Argument = new Argument<DirectoryInfo>().ExistingOnly()
+                    Argument = new Argument<DirectoryInfo>()
                 },
 
                 new Option<string[]>(


### PR DESCRIPTION
Previously, the output directory had to exist even though there were no
doctests defined in the input directory. This makes the tool a bit
clumsy to use when we do not want to have empty test projects.