### PR TITLE
Fix missing parentheses in generated code

### DIFF
--- a/src/DoctestCsharp.Test/TestGeneration.cs
+++ b/src/DoctestCsharp.Test/TestGeneration.cs
@@ -110,13 +110,13 @@ namespace SomeNamespace.Tests
     public class DocTests
     {
         [Test]
-        public void AtLine10AndColumn11
+        public void AtLine10AndColumn11()
         {
             var a = 1;
         }
 
         [Test]
-        public void AtLine20AndColumn21
+        public void AtLine20AndColumn21()
         {
             var b = 2;
         }
@@ -128,13 +128,13 @@ namespace AnotherNamespace.Tests
     public class DocTests
     {
         [Test]
-        public void AtLine30AndColumn31
+        public void AtLine30AndColumn31()
         {
             var c = 3;
         }
 
         [Test]
-        public void AtLine40AndColumn41
+        public void AtLine40AndColumn41()
         {
             var d = 4;
         }
@@ -146,13 +146,13 @@ namespace SomeNamespace.Tests
     public class DocTests2
     {
         [Test]
-        public void AtLine50AndColumn51
+        public void AtLine50AndColumn51()
         {
             var e = 5;
         }
 
         [Test]
-        public void AtLine60AndColumn61
+        public void AtLine60AndColumn61()
         {
             var f = 6;
         }

--- a/src/DoctestCsharp.Test/TestProcess.cs
+++ b/src/DoctestCsharp.Test/TestProcess.cs
@@ -98,7 +98,7 @@ namespace Tests
     public class DocTests
     {
         [Test]
-        public void AtLine0AndColumn4
+        public void AtLine0AndColumn4()
         {
             var x = 1;
         }
@@ -161,7 +161,7 @@ namespace Tests
     public class DocTests
     {
         [Test]
-        public void AtLine1AndColumn4
+        public void AtLine1AndColumn4()
         {
             var x = 1;
         }

--- a/src/DoctestCsharp.Test/TestProgram.cs
+++ b/src/DoctestCsharp.Test/TestProgram.cs
@@ -160,7 +160,7 @@ namespace Tests
     public class DocTests
     {
         [Test]
-        public void AtLine0AndColumn4
+        public void AtLine0AndColumn4()
         {
             var x = 1;
         }

--- a/src/DoctestCsharp/Generation.cs
+++ b/src/DoctestCsharp/Generation.cs
@@ -192,7 +192,7 @@ namespace DoctestCsharp
 
                     var doctest = namespacedDoctests.Doctests[i];
                     block.WriteLine("        [Test]");
-                    block.WriteLine($"        public void AtLine{doctest.Line}AndColumn{doctest.Column}");
+                    block.WriteLine($"        public void AtLine{doctest.Line}AndColumn{doctest.Column}()");
                     block.WriteLine("        {"); // method opening
 
                     block.WriteLine(


### PR DESCRIPTION
This is a minor fix; the generated code missed empty parantheses
(`public void At...()`). This patch fixes this omission.