### PR TITLE
Allow multiple input-output pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,19 @@ For example:
 /// </code>
 ``` 
 
-**Input and output**. You need to specify the project folder (`--input`) and 
-the folder containing the generated doctests (`--output`). Doctest-csharp will 
-scan all the `**/*.cs` files in the input and generate the unit tests in 
-the output.
+**Input and output**. You need to specify one or more pairs consisting of 
+a project folder ("input") and a test folder ("output"). The pair is given 
+as a concatenation `{input}{PATH separator}{output}`. For example, on a Linux 
+system the input-output pair might be something like: 
+`SomeProject:SomeProject.Doctests`. The same input-output pair in Windows is:
+`SomeProject;SomeProject.Doctests`.
+
+If you omit the output (*e.g.*, `SomeProject:` on Linux), the output is 
+automatically inferred by appending the `--suffix` command-line argument.
+The default `--suffix` is `.Tests`.
+
+Doctest-csharp will scan all the `**/*.cs` files in the input folder and 
+generate the unit tests in the output folder.
 
 The relative paths will be preserved. The resulting doctest files will be 
 prefixed with `DocTest`.
@@ -72,13 +81,26 @@ For example:
 
 ```bash
 dotnet doctest-csharp \
-    --input SomeProject
-    --output SomeProject.Test/doctests
+    --input-output SomeProject:SomeProject.Tests/doctests
 ```
 
 Assume there exists `SomeProject/SomeFile.cs`. Doctest-csharp will scan it
 and generate the corresponding doctests to 
-`SomeProject.Test/doctests/DocTestSomeFile.cs`. 
+`SomeProject.Tests/doctests/DocTestSomeFile.cs`. 
+
+In case you have multiple projects all following the same naming convention,
+you can specify `--suffix` and pass in multiple input-only pairs. For example:
+
+```bash
+dotnet doctest-csharp \
+    --input-output \
+        SomeProject: \
+        AnotherProject: \
+    --suffix ".Tests/doctests"
+```
+
+The corresponding inferred outputs will be `SomeProject.Tests/doctests` and
+`AnotherProject.Tests/doctests`, respectively.
 
 **Exclude**. If you want to exclude certain files from the scan, use `--exclude`
 with a Glob pattern.
@@ -87,8 +109,7 @@ For example:
 
 ```bash
 dotnet doctest-csharp \
-    --input SomeProject
-    --output SomeProject.Test/doctests
+    --input-output SomeProject:SomeProject.Test/doctests
     --exclude '**/obj/**'
 ```
 
@@ -182,9 +203,8 @@ For example:
 
 ```bash
 dotnet doctest-csharp \
-    --input SomeProject
-    --output SomeProject.Test/doctests \
-    -- check
+    --input-output SomeProject:SomeProject.Test/doctests \
+    --check
 ```
 
 ## Contributing

--- a/src/DoctestCsharp.Test/TestInput.cs
+++ b/src/DoctestCsharp.Test/TestInput.cs
@@ -1,13 +1,117 @@
 using Path = System.IO.Path;
-
 using System.Collections.Generic;
 using System.Linq;
-
 using NUnit.Framework;
 
 namespace DoctestCsharp.Test
 {
-    public class InputTests
+    public class InputOutputParseTests
+    {
+        [Test]
+        public void TestNoInputOutput()
+        {
+            var inputOutputOrError = Input.ParseInputOutput(new string[] { }, ".Tests");
+            Assert.AreEqual(null, inputOutputOrError.Error);
+            Assert.That(
+                inputOutputOrError.InputOutput,
+                Is.EquivalentTo(new List<(string, string)>()));
+        }
+
+        [Test]
+        public void TestSingleInputOutput()
+        {
+            var inputOutputOrError = Input.ParseInputOutput(
+                new[]
+                {
+                    $"someInput{Path.PathSeparator}someOutput"
+                },
+                ".Tests");
+
+            Assert.AreEqual(null, inputOutputOrError.Error);
+            Assert.That(
+                inputOutputOrError.InputOutput,
+                Is.EquivalentTo(
+                    new List<(string, string)>
+                    {
+                        ("someInput", "someOutput")
+                    }));
+        }
+
+        public void TestMultipleInputOutput()
+        {
+            var inputOutputOrError = Input.ParseInputOutput(
+                new[]
+                {
+                    $"someInput{Path.PathSeparator}someOutput",
+                    $"anotherInput{Path.PathSeparator}anotherOutput"
+                },
+                ".Tests");
+
+            Assert.AreEqual(null, inputOutputOrError.Error);
+            Assert.That(
+                inputOutputOrError.InputOutput,
+                Is.EquivalentTo(
+                    new List<(string, string)>
+                    {
+                        ("someInput", "someOutput"),
+                        ("anotherInput", "anotherOutput")
+                    }));
+        }
+
+        [Test]
+        public void TestAutomaticOutputOnEmptyOutput()
+        {
+            var inputOutputOrError = Input.ParseInputOutput(
+                new[]
+                {
+                    $"someInput{Path.PathSeparator}"
+                },
+                ".Tests");
+
+            Assert.AreEqual(null, inputOutputOrError.Error);
+            Assert.That(
+                inputOutputOrError.InputOutput,
+                Is.EquivalentTo(
+                    new List<(string, string)>
+                    {
+                        ("someInput", "someInput.Tests")
+                    }));
+        }
+
+        [Test]
+        public void TestAutomaticOutputOnNoOutput()
+        {
+            var inputOutputOrError = Input.ParseInputOutput(
+                new[]
+                {
+                    "someInput"
+                },
+                ".Tests");
+
+            Assert.AreEqual(null, inputOutputOrError.Error);
+            Assert.That(
+                inputOutputOrError.InputOutput,
+                Is.EquivalentTo(
+                    new List<(string, string)>
+                    {
+                        ("someInput", "someInput.Tests")
+                    }));
+        }
+
+        [Test]
+        public void TestError()
+        {
+            string inputOutputRaw = $"someInput{Path.PathSeparator}someOutput{Path.PathSeparator}something wrong";
+            var inputOutputOrError = Input.ParseInputOutput(new[] { inputOutputRaw }, ".Tests");
+
+            Assert.AreEqual(
+                $"Expected at most a pair, but got 3 parts " +
+                $"separated by {Path.PathSeparator} from the input-output: {inputOutputRaw}",
+                inputOutputOrError.Error);
+        }
+    }
+
+    public class MatchFilesTests
     {
         private static void WriteDummyFile(string prefix, string dirName, string subdirName, string name)
         {

--- a/src/DoctestCsharp.Test/TestProcess.cs
+++ b/src/DoctestCsharp.Test/TestProcess.cs
@@ -1,5 +1,4 @@
 using Path = System.IO.Path;
-using DirectoryInfo = System.IO.DirectoryInfo;
 using File = System.IO.File;
 
 using CSharpSyntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree;
@@ -17,7 +16,7 @@ namespace DoctestCsharp.Test
         {
             using var tmpdir = new TemporaryDirectory();
 
-            string got = Process.InputPath("SomeProgram.cs", new DirectoryInfo(tmpdir.Path));
+            string got = Process.InputPath("SomeProgram.cs", tmpdir.Path);
 
             Assert.AreEqual(Path.Join(tmpdir.Path, "SomeProgram.cs"), got);
         }
@@ -39,7 +38,7 @@ namespace DoctestCsharp.Test
                 using var tmpdir = new TemporaryDirectory();
 
                 string absoluteOutputPath = Process.OutputPath(
-                    relativePath, new DirectoryInfo(tmpdir.Path));
+                    relativePath, tmpdir.Path);
 
                 string relativeOutputPath = Path.GetRelativePath(tmpdir.Path, absoluteOutputPath);
 

--- a/src/DoctestCsharp.Test/TestProgram.cs
+++ b/src/DoctestCsharp.Test/TestProgram.cs
@@ -22,8 +22,7 @@ namespace DoctestCsharp.Test
 
             Assert.AreEqual(1, exitCode);
             Assert.AreEqual(
-                $"Option '--input' is required.{nl}" +
-                $"Option '--output' is required.{nl}{nl}",
+                $"Option '--input-output' is required.{nl}{nl}",
                 consoleCapture.Error());
         }
 
@@ -38,8 +37,7 @@ namespace DoctestCsharp.Test
 
             Assert.AreEqual(1, exitCode);
             Assert.AreEqual(
-                $"Option '--input' is required.{nl}" +
-                $"Option '--output' is required.{nl}" +
+                $"Option '--input-output' is required.{nl}" +
                 $"Unrecognized command or argument '--invalid-arg'{nl}{nl}",
                 consoleCapture.Error());
         }
@@ -61,7 +59,8 @@ namespace DoctestCsharp.Test
 
             using var consoleCapture = new ConsoleCapture();
 
-            int exitCode = Program.MainWithCode(new[] { "--input", input.FullName, "--output", output.FullName });
+            int exitCode = Program.MainWithCode(
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}" });
 
             string nl = Environment.NewLine;
 
@@ -69,6 +68,8 @@ namespace DoctestCsharp.Test
             Assert.AreEqual(
                 $"No doctests found in: {inputPath}{nl}",
                 consoleCapture.Output());
+
+            Assert.IsFalse(File.Exists(outputPath));
         }
 
         [Test]
@@ -90,7 +91,8 @@ namespace DoctestCsharp.Test
 
             using var consoleCapture = new ConsoleCapture();
 
-            int exitCode = Program.MainWithCode(new[] { "--input", input.FullName, "--output", output.FullName });
+            int exitCode = Program.MainWithCode(
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}" });
 
             string nl = Environment.NewLine;
 
@@ -120,7 +122,8 @@ namespace DoctestCsharp.Test
 
             using var consoleCapture = new ConsoleCapture();
 
-            int exitCode = Program.MainWithCode(new[] { "--input", input.FullName, "--output", output.FullName });
+            int exitCode = Program.MainWithCode(
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}" });
 
             string nl = Environment.NewLine;
 
@@ -174,7 +177,7 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input", input.FullName, "--output", output.FullName, "--check" });
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
 
             string nl = Environment.NewLine;
 
@@ -205,12 +208,14 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input", input.FullName, "--output", output.FullName, "--check" });
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
 
             string nl = Environment.NewLine;
 
             Assert.AreEqual(1, exitCode);
-            Assert.AreEqual($"Output file does not exist: {inputPath} -> {outputPath}{nl}", consoleCapture.Output());
+            Assert.AreEqual(
+                $"Output file does not exist: {inputPath} -> {outputPath}{nl}",
+                consoleCapture.Output());
         }
 
         [Test]
@@ -235,7 +240,7 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input", input.FullName, "--output", output.FullName, "--check" });
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
 
             string nl = Environment.NewLine;
 
@@ -262,7 +267,7 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input", input.FullName, "--output", output.FullName, "--check" });
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
 
             string nl = Environment.NewLine;
 
@@ -285,7 +290,8 @@ namespace Tests
 
             using var consoleCapture = new ConsoleCapture();
 
-            int exitCode = Program.MainWithCode(new[] { "--input", input.FullName, "--output", output, "--check" });
+            int exitCode = Program.MainWithCode(
+                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output}", "--check" });
 
             string nl = Environment.NewLine;
 

--- a/src/DoctestCsharp/Process.cs
+++ b/src/DoctestCsharp/Process.cs
@@ -9,17 +9,17 @@ namespace DoctestCsharp
 {
     public static class Process
     {
-        public static string InputPath(string relativePath, DirectoryInfo input)
+        public static string InputPath(string relativePath, string input)
         {
             if (Path.IsPathRooted(relativePath))
             {
                 throw new ArgumentException($"Expected a relative path, but got a rooted one: {relativePath}");
             }
 
-            return Path.Join(input.FullName, relativePath);
+            return Path.Join(input, relativePath);
         }
 
-        public static string OutputPath(string relativePath, DirectoryInfo output)
+        public static string OutputPath(string relativePath, string output)
         {
             if (Path.IsPathRooted(relativePath))
             {
@@ -30,7 +30,7 @@ namespace DoctestCsharp
                 Path.GetDirectoryName(relativePath),
                 "DocTest" + Path.GetFileName(relativePath));
 
-            return Path.Join(output.FullName, doctestRelativePath);
+            return Path.Join(output, doctestRelativePath);
         }
 
         /// <summary>


### PR DESCRIPTION
Checking and generating a single input-output pair proved to be too
cumbersome on an actual code base
(https://github.com/admin-shell-io/aasx-package-explorer) since the
tool had to start up at each project individually.

This patch changes the command-line interface to accept multiple
input-output pairs so that the user is spared the start-up time
between the projects.