### PR TITLE
Simplify example paths in Readme

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.7
+        uses: mristin/opinionated-commit-message@v2.0.0-pre4
+        with:
+          additional-verbs: 'simplify'
 
       - name: Install .NET core
         uses: actions/setup-dotnet@v1

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ For example:
 a project folder ("input") and a test folder ("output"). The pair is given 
 as a concatenation `{input}{PATH separator}{output}`. For example, on a Linux 
 system the input-output pair might be something like: 
-`SomeProject:SomeProject.Doctests`. The same input-output pair in Windows is:
-`SomeProject;SomeProject.Doctests`.
+`SomeProject:SomeProject.Tests`. The same input-output pair in Windows is:
+`SomeProject;SomeProject.Tests`.
 
 If you omit the output (*e.g.*, `SomeProject:` on Linux), the output is 
 automatically inferred by appending the `--suffix` command-line argument.
@@ -109,7 +109,7 @@ For example:
 
 ```bash
 dotnet doctest-csharp \
-    --input-output SomeProject:SomeProject.Test/doctests
+    --input-output SomeProject:
     --exclude '**/obj/**'
 ```
 
@@ -203,7 +203,7 @@ For example:
 
 ```bash
 dotnet doctest-csharp \
-    --input-output SomeProject:SomeProject.Test/doctests \
+    --input-output SomeProject:
     --check
 ```
 


### PR DESCRIPTION
This is a minor fix to make the examples more readable by omitting
unnecessary clutter in terms of output paths.