### PR TITLE
Reference related tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ https://docs.python.org/3/library/doctest.html
 )), but somewhat surprisingly as of this writing in July 2020, C# lacks it.
 Therefore we decided to roll out doctest-csharp.
 
+## Related Projects
+
+**Doctest for F#**. There exists [doctest for F#](
+https://github.com/moodmosaic/doctest/
+) which is almost identical to doctest-csharp, just for F#.
+
+**[Dotnet-try](https://github.com/dotnet/try)** pursues a similar, and more 
+ambitious, goal of interactive code samples (akin to a 
+[REPL](
+https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop
+) for C#). The tool provides interactive markdown files and requires Visual
+Studio running (at the time of the writing in July 2020, see 
+[this section in their Readme](
+https://github.com/dotnet/try#online-powered-by-blazor
+) and [this one](
+https://github.com/dotnet/try#interactive-net-core-documentation-with-the-dotnet-try-global-tool
+)). While code snippets from the structured comments will probably be added
+in the near future, Dotnet-try focuses on the markdown at the moment.
+If all you need are *static* code examples extracted from structured comments 
+and added to your test suite, doctest-csharp is probably a better light-weight 
+alternative.
+
 ## Installation
 
 Doctest-csharp is distributed and run as a dotnet tool.


### PR DESCRIPTION
It turns out there are related tools - doctest for F# and dotnet-try.
This patch clarifies their differences to doctest-csharp.