### PR TITLE
Give help overview in Readme

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,14 @@ jobs:
         working-directory: src
         run: dotnet dead-csharp --inputs '**/*.cs' --excludes '**/obj/**'
 
+      - name: dotnet publish
+        working-directory: src
+        run: dotnet publish -c Release -o ..\out
+
+      - name: Check help in Readme
+        working-directory: src
+        run: powershell .\CheckHelpInReadme.ps1
+
       - name: Test
         working-directory: src
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 # Vim files
 *.swp
+
+out/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,30 @@ dotnet tool install DoctestCsharp
 
 ## Usage
 
+**Overview.** To obtain an overview of the command-line arguments, use `--help`:
+
+```bash
+dotnet doctest-csharp --help
+```
+<!--- Help starts. -->
+```
+DoctestCsharp:
+  Generates tests from the embedded code snippets in the code documentation.
+
+Usage:
+  DoctestCsharp [options]
+
+Options:
+  --input-output <input-output> (REQUIRED)    Input and output directory pairs containing the *.cs files The input is separated from the output by the PATH separator (e.g., ';' on Windows, ':' on POSIX).If no output is specified, the --suffix is appended to the input to automatically obtain the output.
+  -s, --suffix <suffix>                       Suffix to be automatically appended to the input to obtain the output directory in cases where no explicit output directory was given [default: .Tests]
+  -e, --excludes <excludes>                   Glob patterns of the files to be excluded from the input. The exclude patterns are either absolute (e.g., rooted with '/') or relative. In case of relative exclude patterns, they are relative to the _input_ directory and NOT to the current working directory.
+  -c, --check                                 If set, does not generate any files, but only checks that the content of the test files coincides with what would be generated. This is particularly useful in continuous integration pipelines if you want to check if all the files have been scanned and correctly generated.
+  --version                                   Show version information
+  -?, -h, --help                              Show help and usage information
+```
+<!--- Help ends. -->
+
+
 **Mark the code snippets.** You need to explicitly mark which `<code>...</code>`
 snippets in your documentation should be tested by adding the `doctest` 
 attribute and setting it to `true`.

--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -32,11 +32,18 @@ function Main
     }
 
     Write-Host "Running the unit tests..."
-    dotnet test /p:CollectCoverage=true
+    dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     if ($LASTEXITCODE -ne 0)
     {
         throw "The unit tests failed."
     }
+
+    $outDir = Join-Path (Split-Path -Parent $PSScriptRoot) "out"
+    Write-Host "Publishing to $outDir ..."
+    dotnet publish -c Release -o $outDir
+
+    Write-Host "Checking --help in Readme..."
+    ./CheckHelpInReadme.ps1
 
     Pop-Location
 }

--- a/src/CheckHelpInReadme.ps1
+++ b/src/CheckHelpInReadme.ps1
@@ -1,0 +1,107 @@
+<#
+.DESCRIPTION
+This script checks that the help output from the program and the message
+documented in the Readme coincide.
+#>
+
+function Main
+{
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+
+    $buildDir = Join-Path $repoRoot "out"
+
+    if (!(Test-Path $buildDir))
+    {
+        throw ("The build directory does not exist: $buildDir; " +
+                "did you `dotnet publish -c Release` to it?")
+    }
+
+    $program = Join-Path $buildDir "DoctestCsharp"
+    if (!(Test-Path $program))
+    {
+        $program = Join-Path $buildDir "DoctestCsharp.exe"
+
+        if (!(Test-Path $program))
+        {
+            throw ("The program could not be found " +
+                    "in the build directory: $buildDir; " +
+                    "did you `dotnet publish -c Release` to it?")
+        }
+    }
+
+    $help = & $program --help |Out-String
+
+    # Trim the help so that the message does not take unnecessary space in the
+    # Readme
+    $help = $help.Trim()
+
+    # Make help lines valid markdown to make the comparison against Readme
+    # a bit more concise
+    $helpLines = (
+        @("``````") +
+        $help.Split(@("`r`n", "`r", "`n"), [StringSplitOptions]::None) +
+        @("``````"))
+
+    $readmePath = Join-Path $repoRoot "README.md"
+    if (!(Test-Path $readmePath))
+    {
+        throw "The readme could not be found: $readmePath"
+    }
+    $readme = Get-Content $readmePath
+
+    $readmeLines = $readme.Split(
+            @("`r`n", "`r", "`n"), [StringSplitOptions]::None)
+
+    $startMarker = "<!--- Help starts. -->"
+    $endMarker = "<!--- Help ends. -->"
+
+    $startMarkerAt = -1
+    $endMarkerAt = -1
+    for($i = 0; $i -lt $readmeLines.Length; $i++)
+    {
+        $trimmed = $readmeLines[$i].Trim()
+        if ($trimmed -eq "<!--- Help starts. -->")
+        {
+            $startMarkerAt = $i
+        }
+
+        if ($trimmed -eq "<!--- Help ends. -->")
+        {
+            $endMarkerAt = $i
+        }
+    }
+
+    if ($startMarkerAt -eq -1)
+    {
+        throw "The start marker $startMarker could not be found in: $readmePath"
+    }
+    if ($endMarkerAt -eq -1)
+    {
+        throw "The end marker $endMarker could not be found in: $readmePath"
+    }
+
+    $lineCount = $endMarkerAt - $startMarkerAt - 1
+    if ($lineCount -ne $helpLines.Length)
+    {
+        throw ("--help gave $( $helpLines.Length ) line(s), " +
+                "while Readme contained $lineCount line(s).")
+    }
+
+    for($i = $startMarkerAt + 1; $i -lt $endMarkerAt; $i++)
+    {
+        $helpLineIdx = $i - $startMarkerAt - 1
+        $helpLine = $helpLines[$helpLineIdx]
+        $readmeLine = $readmeLines[$i]
+        if ($helpLine -ne $readmeLine)
+        {
+            throw (
+            "The line $( $i + 1 ) in $readmePath does not " +
+                    "coincide with the line $( $helpLineIdx + 1 ) of --help: " +
+                    "$( $readmeLine|ConvertTo-Json ) != " +
+                    $( $helpLine|ConvertTo-Json ))
+        }
+    }
+    Write-Host "The --help message coincides with the Readme."
+}
+
+Main


### PR DESCRIPTION
This change gives the overview of `--help` in the Readme and makes sure
that this overview coincides with the actual output when `--help` has
been specified.