### PR TITLE
Add `--verbose` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Options:
   -s, --suffix <suffix>                       Suffix to be automatically appended to the input to obtain the output directory in cases where no explicit output directory was given [default: .Tests]
   -e, --excludes <excludes>                   Glob patterns of the files to be excluded from the input. The exclude patterns are either absolute (e.g., rooted with '/') or relative. In case of relative exclude patterns, they are relative to the _input_ directory and NOT to the current working directory.
   -c, --check                                 If set, does not generate any files, but only checks that the content of the test files coincides with what would be generated. This is particularly useful in continuous integration pipelines if you want to check if all the files have been scanned and correctly generated.
+  --verbose                                   If set, outputs only important messages to the users such as errors
   --version                                   Show version information
   -?, -h, --help                              Show help and usage information
 ```

--- a/src/DoctestCsharp.Test/TestProgram.cs
+++ b/src/DoctestCsharp.Test/TestProgram.cs
@@ -60,7 +60,11 @@ namespace DoctestCsharp.Test
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}" });
+                new[]
+                {
+                    "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 
@@ -92,7 +96,11 @@ namespace DoctestCsharp.Test
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}" });
+                new[]
+                {
+                    "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 
@@ -177,7 +185,12 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
+                new[]
+                {
+                    "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}",
+                    "--check",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 
@@ -208,7 +221,12 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
+                new[]
+                {
+                    "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}",
+                    "--check",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 
@@ -240,7 +258,12 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
+                new[]
+                {
+                    "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}",
+                    "--check",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 
@@ -267,7 +290,12 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}", "--check" });
+                new[]
+                {
+                    "--input-output", $"{input.FullName}{Path.PathSeparator}{output.FullName}",
+                    "--check",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 
@@ -291,7 +319,12 @@ namespace Tests
             using var consoleCapture = new ConsoleCapture();
 
             int exitCode = Program.MainWithCode(
-                new[] { "--input-output", $"{input.FullName}{Path.PathSeparator}{output}", "--check" });
+                new[]
+                {
+                    "--input-output", $"{input.FullName}{Path.PathSeparator}{output}",
+                    "--check",
+                    "--verbose"
+                });
 
             string nl = Environment.NewLine;
 

--- a/src/DoctestCsharp/Program.cs
+++ b/src/DoctestCsharp/Program.cs
@@ -13,7 +13,7 @@ namespace DoctestCsharp
 {
     public class Program
     {
-        private static int Handle(string[] inputOutput, string suffix, string[]? excludes, bool check)
+        private static int Handle(string[] inputOutput, string suffix, string[]? excludes, bool check, bool verbose)
         {
             int exitCode = 0;
 
@@ -82,10 +82,14 @@ namespace DoctestCsharp
                     if (!check)
                     {
                         bool generated = Process.Generate(doctests, relativePath, outputPath);
-                        Console.WriteLine(
-                            generated
-                                ? $"Generated doctest(s) for: {inputPath} -> {outputPath}"
-                                : $"No doctests found in: {inputPath}");
+
+                        if (verbose)
+                        {
+                            Console.WriteLine(
+                                generated
+                                    ? $"Generated doctest(s) for: {inputPath} -> {outputPath}"
+                                    : $"No doctests found in: {inputPath}");
+                        }
                     }
                     else
                     {
@@ -93,10 +97,13 @@ namespace DoctestCsharp
                         switch (report)
                         {
                             case Process.Report.Ok:
-                                Console.WriteLine(
-                                    (doctests.Count > 0)
-                                        ? $"OK: {inputPath} -> {outputPath}"
-                                        : $"OK, no doctests: {inputPath}");
+                                if (verbose)
+                                {
+                                    Console.WriteLine(
+                                        (doctests.Count > 0)
+                                            ? $"OK: {inputPath} -> {outputPath}"
+                                            : $"OK, no doctests: {inputPath}");
+                                }
                                 break;
                             case Process.Report.Different:
                                 Console.WriteLine($"Expected different content: {inputPath} -> {outputPath}");
@@ -163,12 +170,17 @@ namespace DoctestCsharp
                     "This is particularly useful " +
                     "in continuous integration pipelines if you want to check if all the files " +
                     "have been scanned and correctly generated."
-                )
+                ),
+
+                new Option<bool>(
+                    new[] {"--verbose"},
+                    "If set, outputs only important messages to the users such as errors"
+                    )
             };
 
             rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create(
-                (string[] inputOutput, string suffix, string[]? excludes, bool check) =>
-                    Handle(inputOutput, suffix, excludes, check));
+                (string[] inputOutput, string suffix, string[]? excludes, bool check, bool verbose) =>
+                    Handle(inputOutput, suffix, excludes, check, verbose));
 
             int exitCode = rootCommand.InvokeAsync(args).Result;
             return exitCode;


### PR DESCRIPTION
A verbose output is good for, *e.g.*, tracking the progress and
verifying that all the files are checked as expected. For set projects
in which new files are rarely added verbose output actually makes
tracing errors very difficult. The user needs to go through a long list
of "OK" messages only to find one or two errors.

This patch introduces the command-line argument `--verbose` so that the
developer can choose which setting is preferred (progress bar *versus*
compact error messages).