### PR TITLE
Put back bite-sized in `Check.ps1`

### DIFF
--- a/src/Check.ps1
+++ b/src/Check.ps1
@@ -17,12 +17,12 @@ function Main
         throw "Format check failed."
     }
 
-#     Write-Host "Checking the line length and number of lines per file..."
-#     dotnet bite-sized --inputs '**/*.cs' --excludes '**/obj/**'
-#     if ($LASTEXITCODE -ne 0)
-#     {
-#         throw "The check of line width failed."
-#     }
+     Write-Host "Checking the line length and number of lines per file..."
+     dotnet bite-sized --inputs '**/*.cs' --excludes '**/obj/**'
+     if ($LASTEXITCODE -ne 0)
+     {
+         throw "The check of line width failed."
+     }
 
     Write-Host "Checking the dead code..."
     dotnet dead-csharp --inputs '**/*.cs' --excludes '**/obj/**'


### PR DESCRIPTION
We commented out `bite-sized` command in `Check.ps1` in
the pull request #18 by mistake.